### PR TITLE
Problem 85: Make the 404 page navigable.

### DIFF
--- a/Authorization/Authentication/AuthenticationStartupFilter.cs
+++ b/Authorization/Authentication/AuthenticationStartupFilter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net;
 using System.Web;
-using Starcounter.Advanced;
 using Starcounter.Blending.Codehost;
 using Starcounter.Startup.Abstractions;
 
@@ -14,6 +13,7 @@ namespace Starcounter.Authorization.Authentication
                                                           + @"<template><dom-bind><template is=""dom-bind"">"
                                                           + @"<palindrom-redirect history url$=""{{model.RedirectUrl}}""></palindrom-redirect>"
                                                           + @"</template></dom-bind></template>";
+
         private readonly IAuthenticationUriProvider _authenticationUriProvider;
         private readonly IAuthCookieService _authCookieService;
         private readonly ISignOutService _signOutService;
@@ -33,6 +33,7 @@ namespace Starcounter.Authorization.Authentication
             return app => {
                 RegisterHtmlPage(_authenticationUriProvider.RedirectionViewUri, RedirectionPageViewContent);
                 RegisterHtmlPage(_authenticationUriProvider.UnauthenticatedViewUri, UnauthenticatedPageViewContent);
+                RegisterHtmlPage(_authenticationUriProvider.UnauthorizedViewUri, Fetch404Template());
 
                 Blender.MapUri(_authenticationUriProvider.UnauthenticatedUriTemplate, string.Empty, new[] { "redirection" });
                 Handle.GET(_authenticationUriProvider.UnauthenticatedUriTemplate,
@@ -74,6 +75,19 @@ namespace Starcounter.Authorization.Authentication
                     response.ContentType = "text/html";
                     return response;
                 });
+        }
+
+        private static string Fetch404Template()
+        {
+            try
+            {
+                string notFoundHTMLUrl = "/sys/error/404.html";
+                return Self.GET(notFoundHTMLUrl).Body;
+            }
+            catch
+            {
+                return "404 Page Not Found";
+            }
         }
     }
 }

--- a/Authorization/Authentication/AuthenticationStartupFilter.cs
+++ b/Authorization/Authentication/AuthenticationStartupFilter.cs
@@ -86,7 +86,7 @@ namespace Starcounter.Authorization.Authentication
             }
             catch
             {
-                return "404 Page Not Found";
+                return "<template><h1>404 Page Not Found</h1></template>";
             }
         }
     }

--- a/Authorization/Authentication/AuthenticationUriProvider.cs
+++ b/Authorization/Authentication/AuthenticationUriProvider.cs
@@ -14,6 +14,9 @@ namespace Starcounter.Authorization.Authentication
         public string UnauthenticatedViewUri =>
             $"/{Application.Current}/Starcounter.Authorization.Unauthenticated.html";
 
+        public string UnauthorizedViewUri =>
+            $"/{Application.Current}/Starcounter.Authorization.Unauthorized.html";
+
         public string RedirectionViewUri =>
             $"/{Application.Current}/Starcounter.Authorization.Redirection.html";
 

--- a/Authorization/Middleware/DefaultSecurityMiddlewareOptions.cs
+++ b/Authorization/Middleware/DefaultSecurityMiddlewareOptions.cs
@@ -1,4 +1,6 @@
-﻿using System.Web;
+﻿using System;
+using System.Net;
+using System.Web;
 using Microsoft.Extensions.Options;
 using Starcounter.Startup.Routing.Middleware;
 
@@ -36,7 +38,22 @@ namespace Starcounter.Authorization.Middleware
 
         private Response CreateDefaultUnauthorizedResponse()
         {
-            return new Response() { StatusCode = (ushort)System.Net.HttpStatusCode.NotFound };
+            var response = Response.FromStatusCode((int)HttpStatusCode.NotFound, Fetch404Template());
+            response.ContentType = "text/html";
+            return response;
+        }
+
+        private static string Fetch404Template()
+        {
+            try
+            {
+                string appShellHTMLUrl = "/sys/error/404.html";
+                return Self.GET(appShellHTMLUrl).Body;
+            }
+            catch
+            {
+                return "Page not found";
+            }
         }
     }
 }

--- a/Authorization/Middleware/DefaultSecurityMiddlewareOptions.cs
+++ b/Authorization/Middleware/DefaultSecurityMiddlewareOptions.cs
@@ -46,7 +46,8 @@ namespace Starcounter.Authorization.Middleware
             var response = new Response()
             {
                 Resource = json,
-                StatusCode = (int) HttpStatusCode.NotFound
+                StatusCode = (int) HttpStatusCode.NotFound,
+                StatusDescription = "Not Found"
             };
 
             return response;

--- a/Authorization/Middleware/DefaultSecurityMiddlewareOptions.cs
+++ b/Authorization/Middleware/DefaultSecurityMiddlewareOptions.cs
@@ -38,22 +38,18 @@ namespace Starcounter.Authorization.Middleware
 
         private Response CreateDefaultUnauthorizedResponse()
         {
-            var response = Response.FromStatusCode((int)HttpStatusCode.NotFound, Fetch404Template());
-            response.ContentType = "text/html";
-            return response;
-        }
+            var json = new Json
+            {
+                ["Html"] = _authenticationUriProvider.UnauthorizedViewUri
+            };
 
-        private static string Fetch404Template()
-        {
-            try
+            var response = new Response()
             {
-                string appShellHTMLUrl = "/sys/error/404.html";
-                return Self.GET(appShellHTMLUrl).Body;
-            }
-            catch
-            {
-                return "Page not found";
-            }
+                Resource = json,
+                StatusCode = (int) HttpStatusCode.NotFound
+            };
+
+            return response;
         }
     }
 }

--- a/Authorization/PublicInterfaces/IAuthenticationUriProvider.cs
+++ b/Authorization/PublicInterfaces/IAuthenticationUriProvider.cs
@@ -24,6 +24,11 @@ namespace Starcounter.Authorization
         string UnauthenticatedViewUri { get; }
 
         /// <summary>
+        /// The URI under which the HTML file with 404 error message will be registered
+        /// </summary>
+        string UnauthorizedViewUri { get; }
+
+        /// <summary>
         /// The URI under which the HTML file with redirection will be registered
         /// </summary>
         string RedirectionViewUri { get; }


### PR DESCRIPTION
**Problem #85**: 
>We have a problem with how the Authorization library handles the unauthorized/unauthenticated cases.
If you are unauthorized to access a particular page it sends a 404 without a body, which crashes the session irrecoverably.

**Solution:**
Authorization library now tried to response with 404.html static page content and with `HttpStatusCode.NotFound` in the case of the unauthorized request.

**Tests:**
Build and manual test on `Products` + `SignIn` apps.

**Screenshots:**
![image](https://user-images.githubusercontent.com/17431807/52791710-a726ec00-307a-11e9-8e0d-c6b8dc25d1e5.png)

**Significant note**:
Because these changes based on the `3.x` branch which contains packages update https://github.com/Starcounter/Starcounter.Authorization/commit/c0832eff0ffc1c9e96e345580880d16c7fd6d495 (it was forced by releasing the `Blending.Codehost` 0.0.7 that uses newer versions of some packages) in some apps MSBuild will notify you about old versions of some used packages.