### PR TITLE
Problem 89: Create nuspec file for NuGet packaging.

### DIFF
--- a/Authorization/AssemblyInfo.cs
+++ b/Authorization/AssemblyInfo.cs
@@ -1,4 +1,17 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
-[assembly:InternalsVisibleTo("Starcounter.Authorization.Tests")]
+[assembly: InternalsVisibleTo("Starcounter.Authorization.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+[assembly: AssemblyTitle("Starcounter.Authorization")]
+[assembly: AssemblyDescription("Authorization helper library for Starcounter applications")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Starcounter AB")]
+[assembly: AssemblyProduct("Starcounter.Authorization")]
+[assembly: AssemblyCopyright("Copyright © 2019 Starcounter AB")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: AssemblyVersion("3.7.5")]
+[assembly: AssemblyFileVersion("3.7.5")]

--- a/Authorization/Authorization.csproj
+++ b/Authorization/Authorization.csproj
@@ -18,10 +18,10 @@
     <RepositoryUrl>https://github.com/Starcounter/Starcounter.Authorization</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/Starcounter/Starcounter.Authorization/blob/master/LICENSE</PackageLicenseUrl>
     <Description>Authorization helper library for Starcounter applications</Description>
-    <PackageReleaseNotes>See https://github.com/Starcounter/Starcounter.Authorization/releases
-</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/Starcounter/Starcounter.Authorization/releases</PackageReleaseNotes>
     <PackageTags>Starcounter</PackageTags>
     <DocumentationFile>bin\Debug\Starcounter.Authorization.xml</DocumentationFile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
@@ -47,6 +47,9 @@
       <HintPath>$(StarcounterBin)\Starcounter.XSON.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Starcounter.Authorization.nuspec" />
   </ItemGroup>
   <Target Name="PublishArtifacts" AfterTargets="Pack">
     <Message Text="##teamcity[publishArtifacts '%(NugetPackOutput.Identity)']" Condition="%(NuGetPackOutput.Extension) == '.nupkg'" Importance="High" />

--- a/Authorization/Starcounter.Authorization.nuspec
+++ b/Authorization/Starcounter.Authorization.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>Starcounter, joozek78</authors>
+    <owners>Starcounter</owners>
+    <licenseUrl>https://github.com/Starcounter/Starcounter.Authorization/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Starcounter/Starcounter.Authorization</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>$description$</summary>
+    <description>$description$</description>
+    <copyright>$copyright$</copyright>
+    <tags>Starcounter Authorization</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
**Problem: #89** 
>The `nuspec` file is needed for NuGet packaging.

**Solution:**
1. The `.nuspec` file was added.
2. `AssemblyInfo.cs` file was updated to use info from attributes for substitution.

**Tests:**
1. Locally was created `Starcounter.Authorization.3.7.5.nupkg`.
2. Was checked content of the `Starcounter.Authorization.nuspec` from the locally created package:
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
  <metadata>
    <id>Starcounter.Authorization</id>
    <version>3.7.5</version>
    <title>Starcounter.Authorization</title>
    <authors>Starcounter, joozek78</authors>
    <owners>Starcounter</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <licenseUrl>https://github.com/Starcounter/Starcounter.Authorization/blob/master/LICENSE</licenseUrl>
    <projectUrl>https://github.com/Starcounter/Starcounter.Authorization</projectUrl>
    <description>Authorization helper library for Starcounter applications</description>
    <summary>Authorization helper library for Starcounter applications</summary>
    <copyright>Copyright © 2019 Starcounter AB</copyright>
    <tags>Starcounter Authorization</tags>
    <dependencies />
  </metadata>
</package>
```